### PR TITLE
Add transform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ type Foo struct {
 
 ```
 
+If you prefer to use `camelCase` instead of `snake_case` for the values, you can use the `g:go_addtags_transform` variable to define a different transformation rule. The following example uses the `camelCase` transformation rule.
+
+```vim
+let g:go_addtags_transform = 'camelcase'
+```
+
 ## Installation
 
 
@@ -43,4 +49,3 @@ MIT
 ## Author
 
 Yasuhiro Matsumoto (a.k.a. mattn)
-

--- a/ftplugin/go/goaddtags.vim
+++ b/ftplugin/go/goaddtags.vim
@@ -45,7 +45,8 @@ function! s:goaddtags(...) abort
     let l:args += ['--add-options', join(l:options, ' ')]
   endif
   let l:fname = expand('%:p')
-  let l:cmd = printf('gomodifytags -file %s -offset %d %s', shellescape(l:fname), s:bytes_offset(line('.'), col('.')), join(map(l:args, 'shellescape(v:val)'), ' '))
+  let l:transform = get(g:, 'go_addtags_transform', 'snakecase')
+  let l:cmd = printf('gomodifytags -file %s -offset %d -transform %s %s', shellescape(l:fname), s:bytes_offset(line('.'), col('.')), l:transform, join(map(l:args, 'shellescape(v:val)'), ' '))
   let l:out = system(l:cmd)
   let l:lines = split(substitute(l:out, "\n$", '', ''), '\n')
   if v:shell_error != 0


### PR DESCRIPTION
Hi @mattn 

Thank you for the nice plugin. I added a global option to set `gomodifytags`'s transform.
The variable name is `g:go_addtags_transform` (default is `snakecase`, possible variables are `camelcase` and `snakecase`)

Thank you.